### PR TITLE
Fix NPE when accessing cross-references of stubbed categorisation

### DIFF
--- a/SdmxBeans/src/main/java/org/sdmxsource/sdmx/sdmxbeans/model/beans/categoryscheme/CategorisationBeanImpl.java
+++ b/SdmxBeans/src/main/java/org/sdmxsource/sdmx/sdmxbeans/model/beans/categoryscheme/CategorisationBeanImpl.java
@@ -307,9 +307,9 @@ public class CategorisationBeanImpl extends MaintainableBeanImpl implements Cate
 
     @Override
     protected Set<CrossReferenceBean> getCrossReferenceInternal() {
-        Set<CrossReferenceBean> crossReferences = new HashSet<CrossReferenceBean>();
-        crossReferences.add(categoryReference);
-        crossReferences.add(structureReference);
+        Set<CrossReferenceBean> crossReferences = new HashSet<>();
+        if (categoryReference != null) crossReferences.add(categoryReference);
+        if (structureReference != null) crossReferences.add(structureReference);
         return crossReferences;
     }
 


### PR DESCRIPTION
* When categorisation is stubbed meaning that category reference and structure reference are both null, execution of old getCrossReferenceInternal() method would result in non-empty set with one null element. This led to NPE during traversal of the mentioned set