### PR TITLE
Add frequency role check to dimension to initialize isFrequency flag

### DIFF
--- a/SdmxBeans/src/main/java/org/sdmxsource/sdmx/sdmxbeans/model/beans/datastructure/DimensionBeanImpl.java
+++ b/SdmxBeans/src/main/java/org/sdmxsource/sdmx/sdmxbeans/model/beans/datastructure/DimensionBeanImpl.java
@@ -83,6 +83,7 @@ public class DimensionBeanImpl extends ComponentBeanImpl implements DimensionBea
             this.position = position;
             this.measureDimension = bean.isMeasureDimension();
             this.timeDimension = bean.isTimeDimension();
+            this.freqDimension = bean.isFrequencyDimension();
             if (bean.getConceptRole() != null) {
                 for (StructureReferenceBean currentConceptRole : bean.getConceptRole()) {
                     conceptRole.add(new CrossReferenceBeanImpl(this, currentConceptRole));

--- a/SdmxBeans/src/main/java/org/sdmxsource/sdmx/sdmxbeans/model/mutable/datastructure/DimensionMutableBeanImpl.java
+++ b/SdmxBeans/src/main/java/org/sdmxsource/sdmx/sdmxbeans/model/mutable/datastructure/DimensionMutableBeanImpl.java
@@ -30,6 +30,7 @@ package org.sdmxsource.sdmx.sdmxbeans.model.mutable.datastructure;
 import org.sdmxsource.sdmx.api.constants.SDMX_STRUCTURE_TYPE;
 import org.sdmxsource.sdmx.api.model.beans.datastructure.DimensionBean;
 import org.sdmxsource.sdmx.api.model.beans.reference.CrossReferenceBean;
+import org.sdmxsource.sdmx.api.model.beans.reference.IdentifiableRefBean;
 import org.sdmxsource.sdmx.api.model.beans.reference.StructureReferenceBean;
 import org.sdmxsource.sdmx.api.model.mutable.datastructure.DimensionMutableBean;
 import org.sdmxsource.sdmx.sdmxbeans.model.mutable.base.ComponentMutableBeanImpl;
@@ -43,6 +44,8 @@ import java.util.List;
  */
 public class DimensionMutableBeanImpl extends ComponentMutableBeanImpl implements DimensionMutableBean {
     private static final long serialVersionUID = 1L;
+
+    private static final String FREQ = "FREQ";
 
     private boolean measureDimension;
     private boolean frequencyDimension;
@@ -66,11 +69,27 @@ public class DimensionMutableBeanImpl extends ComponentMutableBeanImpl implement
         this.measureDimension = bean.isMeasureDimension();
         this.frequencyDimension = bean.isFrequencyDimension();
         this.timeDimension = bean.isTimeDimension();
-        if (bean.getConceptRole() != null) {
-            for (CrossReferenceBean currentConceptRole : bean.getConceptRole()) {
-                conceptRole.add(currentConceptRole.createMutableInstance());
+        List<CrossReferenceBean> conceptRole = bean.getConceptRole();
+        if (conceptRole != null) {
+            for (CrossReferenceBean currentConceptRole : conceptRole) {
+                this.conceptRole.add(currentConceptRole.createMutableInstance());
+                IdentifiableRefBean roleReference = currentConceptRole.getChildReference();
+                checkFrequencyRole(roleReference);
             }
         }
+    }
+
+    private void checkFrequencyRole(IdentifiableRefBean roleReference) {
+        if (isFrequency(roleReference)) {
+            this.frequencyDimension = true;
+        }
+    }
+
+    private boolean isFrequency(IdentifiableRefBean roleReference) {
+        if (roleReference != null) {
+            return FREQ.equals(roleReference.getId());
+        }
+        return false;
     }
 
     @Override
@@ -117,5 +136,11 @@ public class DimensionMutableBeanImpl extends ComponentMutableBeanImpl implement
     @Override
     public void setConceptRole(List<StructureReferenceBean> conceptRole) {
         this.conceptRole = conceptRole;
+        if (conceptRole != null) {
+            for (StructureReferenceBean currentConceptRole : conceptRole) {
+                IdentifiableRefBean roleReference = currentConceptRole.getChildReference();
+                checkFrequencyRole(roleReference);
+            }
+        }
     }
 }

--- a/SdmxBeans/src/test/java/org/sdmxsource/sdmx/sdmxbeans/model/mutable/datastructure/DimensionMutableBeanImplTest.java
+++ b/SdmxBeans/src/test/java/org/sdmxsource/sdmx/sdmxbeans/model/mutable/datastructure/DimensionMutableBeanImplTest.java
@@ -1,0 +1,58 @@
+package org.sdmxsource.sdmx.sdmxbeans.model.mutable.datastructure;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.sdmxsource.sdmx.sdmxbeans.data.DataHelper.getConceptStructureReferenceBean;
+
+class DimensionMutableBeanImplTest {
+    @Test
+    void shouldCheckRolesToSetIsFrequencyFlagWhenSingleRolePresent() {
+        var subject = new DimensionMutableBeanImpl();
+        subject.setConceptRole(singletonList(getConceptStructureReferenceBean("FREQ")));
+
+        assertTrue(subject.isFrequencyDimension());
+    }
+
+    @Test
+    void shouldCheckRolesToSetIsFrequencyFlagWhenMultipleRolesPresent() {
+        var subject = new DimensionMutableBeanImpl();
+        subject.setConceptRole(List.of(
+                getConceptStructureReferenceBean("FREQ"),
+                getConceptStructureReferenceBean("VAR")
+        ));
+
+        assertTrue(subject.isFrequencyDimension());
+    }
+
+    @Test
+    void shouldCheckRolesToSetIsFrequencyFlagWhenNoFrequencyRole() {
+        var subject = new DimensionMutableBeanImpl();
+        subject.setConceptRole(List.of(
+                getConceptStructureReferenceBean("GEO"),
+                getConceptStructureReferenceBean("VAR")
+        ));
+
+        assertFalse(subject.isFrequencyDimension());
+    }
+
+    @Test
+    void shouldCheckRolesToSetIsFrequencyFlagWhenNoRoles() {
+        var subject = new DimensionMutableBeanImpl();
+        subject.setConceptRole(List.of());
+
+        assertFalse(subject.isFrequencyDimension());
+    }
+
+    @Test
+    void shouldCheckRolesToSetIsFrequencyFlagWhenNull() {
+        var subject = new DimensionMutableBeanImpl();
+        subject.setConceptRole(null);
+
+        assertFalse(subject.isFrequencyDimension());
+    }
+}

--- a/SdmxBeans/src/test/java/org/sdmxsource/sdmx/sdmxbeans/test/DsdBeanTest.java
+++ b/SdmxBeans/src/test/java/org/sdmxsource/sdmx/sdmxbeans/test/DsdBeanTest.java
@@ -15,8 +15,11 @@ import org.sdmxsource.sdmx.sdmxbeans.model.mutable.base.TextFormatMutableBeanImp
 import org.sdmxsource.sdmx.sdmxbeans.model.mutable.datastructure.DataStructureMutableBeanImpl;
 import org.sdmxsource.sdmx.sdmxbeans.model.mutable.datastructure.DimensionMutableBeanImpl;
 
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.sdmxsource.sdmx.sdmxbeans.data.DataHelper.getConceptStructureReferenceBean;
 
 public class DsdBeanTest {
@@ -27,6 +30,22 @@ public class DsdBeanTest {
         var immutable = buildDataStructureBean(dimension);
 
         assertNotNull(immutable.getFrequencyDimension());
+    }
+
+    @Test
+    public void shouldReturnFreqDimensionWhenDimensionWithCorrespondingRolePresent() {
+        var immutable = buildDataStructureBean(dimensionBean("beanId", "FREQ"));
+
+        DimensionBean frequencyDimension = immutable.getFrequencyDimension();
+
+        assertEquals("beanId", frequencyDimension.getId());
+    }
+
+    @Test
+    public void shouldNotReturnFreqDimensionWhenCorrespondingRoleMissing() {
+        var immutable = buildDataStructureBean(dimensionBean("beanId", "VAR"));
+
+        assertNull(immutable.getFrequencyDimension());
     }
 
     @Test
@@ -59,6 +78,14 @@ public class DsdBeanTest {
         dsd.addPrimaryMeasure(getConceptStructureReferenceBean("OBS_VALUE"));
         dsd.addDimension(dimension);
         return dsd.getImmutableInstance();
+    }
+
+    private DimensionMutableBean dimensionBean(String id, String roleId) {
+        DimensionMutableBean dimension = new DimensionMutableBeanImpl();
+        dimension.setId(id);
+        dimension.setConceptRole(singletonList(getConceptStructureReferenceBean(roleId)));
+        dimension.setConceptRef(getConceptStructureReferenceBean("FREQ"));
+        return dimension;
     }
 
 }


### PR DESCRIPTION
* when dimension mutable bean gets created, iterate over its roles (if any) and check whether there is a role with 'FREQ' id which would indicate that dimension in question is a freqency dimension.
* use that knowledge when instantiating the dsd bean
* add basic test coverage